### PR TITLE
Bypass django auth on identified url

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ IAP_EXPECTED_AUDIENCE = '/projects/123456789123/locations/europe-west1/services/
 
 # (Optional) Restrict logins to a specific Google Workspace or Cloud Identity domain.
 IAP_EMAIL_DOMAIN = 'emencia.com'
+IAP_EXEMPT_URLS = [
+    "/api/healthcheck/",
+    "/status/"
+]
 ```
 
 ## Usage

--- a/cloudrun_iap_auth/middlewares.py
+++ b/cloudrun_iap_auth/middlewares.py
@@ -39,6 +39,15 @@ class IAPAuthenticationMiddleware(MiddlewareMixin):
             # IAP is not enabled, skip this middleware
             return
 
+        # Check for public URL exceptions
+        iap_exempt_urls = getattr(settings, "IAP_EXEMPT_URLS", [])
+        for url_pattern in iap_exempt_urls:
+            if request.path.startswith(url_pattern):
+                logger.debug(
+                    f"IAP: Bypassing authentication for exempt URL: {request.path}"
+                )
+                return  # Skip IAP authentication for this path
+
         # IAP provides these headers after successful authentication
         iap_user_email_header = "X-Goog-Authenticated-User-Email"
         iap_jwt_assertion_header = "X-Goog-IAP-JWT-Assertion"


### PR DESCRIPTION
Some endpoint can accept request without django login/auth. Provide a way to bypass auth on specified url/path.